### PR TITLE
Add information about API key to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![badge-desktop](http://img.shields.io/badge/platform-ios-EAEAEA.svg?style=flat)
 ![badge-browser](https://img.shields.io/badge/platform-js-F8DB5D.svg?style=flat)
 
-A KMP template of the New York Times App using Compose multiplatform
+A KMP template of the New York Times App using Compose multiplatform. To build and run this application you will need [an API key from the New York Times](https://developer.nytimes.com/).
 
 <img src="https://user-images.githubusercontent.com/13775137/235060514-3b7f8779-7f2b-4f48-8e09-ef89d0a06344.png" width="720">
 


### PR DESCRIPTION
This is a very impressive application. However, when I started playing with it, I was thrown by the fact that it didn't build without an API key. 

In terms of usability, it might be better if there were some dummy stories you could view first. Then you would be more motivated to obtain the API key and see real data.