### PR TITLE
Fix run configurations by updating to latest scheme

### DIFF
--- a/.idea/runConfigurations/app_android.xml
+++ b/.idea/runConfigurations/app_android.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="android" type="AndroidRunConfigurationType" factoryName="Android App">
-    <module name="android.NYTimes-KMP.app.android.main" />
+  <configuration default="false" name="app.android" type="AndroidRunConfigurationType" factoryName="Android App">
+    <module name="NYTimes-KMP.app.android.main" />
     <option name="DEPLOY" value="true" />
     <option name="DEPLOY_APK_FROM_BUNDLE" value="false" />
     <option name="DEPLOY_AS_INSTANT" value="false" />
@@ -9,46 +9,18 @@
     <option name="ALL_USERS" value="false" />
     <option name="ALWAYS_INSTALL_WITH_PM" value="false" />
     <option name="CLEAR_APP_STORAGE" value="false" />
+    <option name="DYNAMIC_FEATURES_DISABLED_LIST" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="default_activity" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="INSPECTION_WITHOUT_ACTIVITY_RESTART" value="false" />
     <option name="TARGET_SELECTION_MODE" value="DEVICE_AND_SNAPSHOT_COMBO_BOX" />
-    <option name="SELECTED_CLOUD_MATRIX_CONFIGURATION_ID" value="-1" />
-    <option name="SELECTED_CLOUD_MATRIX_PROJECT_ID" value="" />
-    <option name="DEBUGGER_TYPE" value="Auto" />
-    <Auto>
-      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
-      <option name="SHOW_STATIC_VARS" value="true" />
-      <option name="WORKING_DIR" value="" />
-      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
-      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
-      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
-      <option name="DEBUG_SANDBOX_SDK" value="false" />
-    </Auto>
-    <Hybrid>
-      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
-      <option name="SHOW_STATIC_VARS" value="true" />
-      <option name="WORKING_DIR" value="" />
-      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
-      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
-      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
-      <option name="DEBUG_SANDBOX_SDK" value="false" />
-    </Hybrid>
+    <option name="DEBUGGER_TYPE" value="Java" />
     <Java>
       <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
       <option name="DEBUG_SANDBOX_SDK" value="false" />
     </Java>
-    <Native>
-      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
-      <option name="SHOW_STATIC_VARS" value="true" />
-      <option name="WORKING_DIR" value="" />
-      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
-      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
-      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
-      <option name="DEBUG_SANDBOX_SDK" value="false" />
-    </Native>
     <Profilers>
       <option name="ADVANCED_PROFILING_ENABLED" value="false" />
       <option name="STARTUP_PROFILING_ENABLED" value="false" />

--- a/.idea/runConfigurations/app_wear.xml
+++ b/.idea/runConfigurations/app_wear.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="wear" type="AndroidRunConfigurationType" factoryName="Android App">
+  <configuration default="false" name="app.wear" type="AndroidRunConfigurationType" factoryName="Android App">
     <module name="NYTimes-KMP.app.wear.main" />
     <option name="DEPLOY" value="true" />
     <option name="DEPLOY_APK_FROM_BUNDLE" value="false" />
@@ -9,46 +9,18 @@
     <option name="ALL_USERS" value="false" />
     <option name="ALWAYS_INSTALL_WITH_PM" value="false" />
     <option name="CLEAR_APP_STORAGE" value="false" />
+    <option name="DYNAMIC_FEATURES_DISABLED_LIST" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="default_activity" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="INSPECTION_WITHOUT_ACTIVITY_RESTART" value="false" />
     <option name="TARGET_SELECTION_MODE" value="DEVICE_AND_SNAPSHOT_COMBO_BOX" />
-    <option name="SELECTED_CLOUD_MATRIX_CONFIGURATION_ID" value="-1" />
-    <option name="SELECTED_CLOUD_MATRIX_PROJECT_ID" value="" />
-    <option name="DEBUGGER_TYPE" value="Auto" />
-    <Auto>
-      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
-      <option name="SHOW_STATIC_VARS" value="true" />
-      <option name="WORKING_DIR" value="" />
-      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
-      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
-      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
-      <option name="DEBUG_SANDBOX_SDK" value="false" />
-    </Auto>
-    <Hybrid>
-      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
-      <option name="SHOW_STATIC_VARS" value="true" />
-      <option name="WORKING_DIR" value="" />
-      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
-      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
-      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
-      <option name="DEBUG_SANDBOX_SDK" value="false" />
-    </Hybrid>
+    <option name="DEBUGGER_TYPE" value="Java" />
     <Java>
       <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
       <option name="DEBUG_SANDBOX_SDK" value="false" />
     </Java>
-    <Native>
-      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
-      <option name="SHOW_STATIC_VARS" value="true" />
-      <option name="WORKING_DIR" value="" />
-      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
-      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
-      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
-      <option name="DEBUG_SANDBOX_SDK" value="false" />
-    </Native>
     <Profilers>
       <option name="ADVANCED_PROFILING_ENABLED" value="false" />
       <option name="STARTUP_PROFILING_ENABLED" value="false" />


### PR DESCRIPTION
Run configurations contained in project repository seems to be outdated and not working with Android Studio, IntelliJ nor Fleet. I've committed the updated versions which are generated by the InteliJ on project opening.

The main and required changes are the names and modules of run configurations. We can consider changing other options to the set of previously occurring options if they were intentional (not auto-generated). We should stick to new naming of run configurations to avoid duplicated run configurations, as it has happened in root problem in [FL-23775](https://youtrack.jetbrains.com/issue/FL-23775).